### PR TITLE
security: harden Docker container configuration

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -40,7 +40,7 @@ LABEL maintainer="alexei-led" \
       org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.created="${BUILD_DATE}"
 
-# Step 1: Install system packages - keeping all original packages
+# Step 1: Install system packages (minimal set for AWS CLI operation)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     unzip \
     curl \
@@ -52,9 +52,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tar \
     gzip \
     zip \
-    vim \
-    net-tools \
-    dnsutils \
     openssh-client \
     grep \
     sed \

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -7,15 +7,25 @@ services:
     # Alternatively, use the pre-built multi-arch image
     # image: ghcr.io/alexei-led/aws-mcp-server:latest
     ports:
-      - "8000:8000"
+      - 8000:8000
     volumes:
-      - ~/.aws://home/appuser/.aws:ro # Mount AWS credentials as read-only
+      - ~/.aws:/home/appuser/.aws:ro # Mount AWS credentials as read-only
     environment:
       - AWS_PROFILE=default # Specify default AWS profile
       - AWS_MCP_TIMEOUT=300 # Default timeout in seconds (5 minutes)
       - AWS_MCP_TRANSPORT=stdio # Transport protocol ("stdio" or "sse")
-      # - AWS_MCP_MAX_OUTPUT=100000  # Uncomment to set max output size
+      # - AWS_MCP_MAX_OUTPUT=100000   # Uncomment to set max output size
     restart: unless-stopped
+    # Security hardening
+    read_only: true # Read-only root filesystem
+    tmpfs:
+      - /tmp:size=64M,mode=1777 # Temporary storage with size limit
+      - /app/logs:size=32M,mode=1777 # Writable logs directory
+    security_opt:
+      - no-new-privileges:true # Prevent privilege escalation
+    cap_drop:
+      - ALL # Drop all Linux capabilities
+    pids_limit: 100 # Prevent fork bombs
 # To build multi-architecture images:
 # 1. Set up Docker buildx: docker buildx create --name mybuilder --use
 # 2. Build and push the multi-arch image:

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -288,6 +288,36 @@ Docker provides stronger isolation than OS-level sandboxing:
 
 **Recommendation**: Use Docker for production deployments. Use sandbox for native Python installations where Docker is not available.
 
+## Docker Container Hardening
+
+When running in Docker, the provided `docker-compose.yml` includes security hardening:
+
+| Setting                  | Purpose                                                                    |
+| ------------------------ | -------------------------------------------------------------------------- |
+| `read_only: true`        | Makes the container filesystem read-only, preventing malicious file writes |
+| `tmpfs` mounts           | Provides writable `/tmp` and `/app/logs` with size limits (64MB, 32MB)     |
+| `no-new-privileges:true` | Prevents processes from gaining additional privileges via setuid/setgid    |
+| `cap_drop: ALL`          | Drops all Linux capabilities - the container runs with minimal privileges  |
+| `pids_limit: 100`        | Limits process count to prevent fork bomb attacks                          |
+
+### Minimal Image
+
+The Docker image is built with only the packages necessary for AWS CLI operation:
+
+- **Included**: AWS CLI, jq, openssh-client (for EC2 connectivity), text processing tools
+- **Excluded**: Debug tools (vim, net-tools, dnsutils) to reduce attack surface
+
+### Volume Mounts
+
+AWS credentials are mounted read-only from the host:
+
+```yaml
+volumes:
+  - ~/.aws:/home/appuser/.aws:ro
+```
+
+The `:ro` flag ensures the container cannot modify your AWS configuration files.
+
 ## Best Practices
 
 1. **Use Docker deployment** for strongest isolation


### PR DESCRIPTION
## Summary

- Add read-only filesystem with tmpfs mounts for `/tmp` and `/app/logs`
- Drop all Linux capabilities (`cap_drop: ALL`)
- Prevent privilege escalation (`no-new-privileges:true`)
- Limit processes to prevent fork bombs (`pids_limit: 100`)
- Remove debug packages (vim, net-tools, dnsutils) from Docker image
- Fix volume mount typo (`~/.aws://home` → `~/.aws:/home`)
- Document security settings in SECURITY.md

## Security Hardening Details

| Setting | Purpose |
| ------- | ------- |
| `read_only: true` | Makes container filesystem read-only, preventing malicious file writes |
| `tmpfs` mounts | Provides writable `/tmp` (64MB) and `/app/logs` (32MB) with size limits |
| `no-new-privileges:true` | Prevents processes from gaining privileges via setuid/setgid |
| `cap_drop: ALL` | Drops all Linux capabilities - container runs with minimal privileges |
| `pids_limit: 100` | Limits process count to prevent fork bomb attacks |

## Test plan

- [x] Docker image builds successfully
- [x] AWS CLI works inside hardened container
- [x] Debug packages (vim, net-tools, dnsutils) are NOT installed
- [x] Essential packages (jq, grep, sed, awk, ssh) ARE installed
- [x] All security settings apply correctly