### PR TITLE
fix: bind SSE to 0.0.0.0 in Docker for port mapping

### DIFF
--- a/src/aws_mcp_server/config.py
+++ b/src/aws_mcp_server/config.py
@@ -81,3 +81,21 @@ AWS RESOURCES (read these for context):
 """
 
 BASE_DIR = Path(__file__).parent.parent.parent
+
+
+def is_docker_environment() -> bool:
+    """Detect if running inside a Docker container.
+
+    Checks for common Docker indicators:
+    - /.dockerenv file (most reliable)
+    - /proc/self/cgroup contains 'docker'
+    """
+    if Path("/.dockerenv").exists():
+        return True
+    try:
+        cgroup_path = Path("/proc/self/cgroup")
+        if cgroup_path.exists():
+            return "docker" in cgroup_path.read_text()
+    except (OSError, IOError):
+        pass
+    return False


### PR DESCRIPTION
## Summary

- Auto-detect Docker environment using `/.dockerenv` and `/proc/self/cgroup`
- Bind SSE server to `0.0.0.0` in Docker (required for port mapping)
- Bind SSE server to `127.0.0.1` on host (secure localhost-only)

## Problem

When running the MCP server in Docker with SSE transport, the server bound to `127.0.0.1:8000` inside the container. This made it inaccessible from the host even with port mapping (`-p 8001:8000`).

## Solution

Smart host binding based on environment detection:
| Environment | Host Binding | Rationale |
|-------------|--------------|-----------|
| Docker | `0.0.0.0` | Required for port mapping to work |
| Host (uvx) | `127.0.0.1` | Secure, localhost-only access |

## Security Considerations

- **Host (uvx with sandbox)**: Binds to localhost only - prevents accidental network exposure
- **Docker**: Binds to all interfaces but Docker's network namespace provides isolation; users can further restrict via `-p 127.0.0.1:8000:8000`

## Test plan

- [x] uvx SSE binds to `127.0.0.1:8000`
- [x] Docker SSE binds to `0.0.0.0:8000`
- [x] Docker SSE accessible from host via port mapping
- [x] All 218 unit tests pass
- [x] Lint/format checks pass