### PR TITLE
fix: add /opt/homebrew to macOS Seatbelt sandbox allowed paths

### DIFF
--- a/src/aws_mcp_server/sandbox.py
+++ b/src/aws_mcp_server/sandbox.py
@@ -161,6 +161,7 @@ class SandboxConfig:
                 "/private/etc",
                 "/var/run",
                 "/dev",
+                "/opt/homebrew",
             ]
         return []
 
@@ -473,6 +474,7 @@ class MacOSSeatbeltBackend(SandboxBackend):
     (subpath "/private/var/run")
     (subpath "/var/run")
     (subpath "/dev")
+    (subpath "/opt/homebrew")
     (subpath "/Applications/Xcode.app")
     (literal "/")
     (literal "/private")


### PR DESCRIPTION
## Summary

- Add `/opt/homebrew` to macOS Seatbelt sandbox read paths to allow AWS CLI execution via uvx on Apple Silicon Macs
- Fixes dyld "file system sandbox blocked open()" errors when running uvx aws-mcp

## Problem

When running `uvx aws-mcp` from Claude Code, AWS CLI commands failed with:
```
dyld: Library not loaded: /opt/homebrew/Cellar/python@3.13/.../Python
Reason: file system sandbox blocked open()
```

The Seatbelt sandbox profile didn't include `/opt/homebrew`, blocking access to Homebrew-installed Python libraries on Apple Silicon Macs.

## Changes

1. Added `/opt/homebrew` to `SandboxConfig._default_read_paths()` for Darwin
2. Added `(subpath "/opt/homebrew")` to `MacOSSeatbeltBackend.PROFILE_TEMPLATE`

## Test plan

- [x] All 220 existing tests pass
- [ ] Manual test: Run `uvx aws-mcp` and execute AWS CLI commands on Apple Silicon Mac