### PR TITLE
feat: Add tool annotations for improved LLM tool understanding

### DIFF
--- a/src/aws_mcp_server/server.py
+++ b/src/aws_mcp_server/server.py
@@ -10,6 +10,7 @@ import logging
 import sys
 
 from mcp.server.fastmcp import Context, FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from aws_mcp_server.cli_executor import (
@@ -45,7 +46,12 @@ register_prompts(mcp)
 register_resources(mcp)
 
 
-@mcp.tool()
+@mcp.tool(
+    annotations=ToolAnnotations(
+        title="AWS CLI Help",
+        readOnlyHint=True,
+    ),
+)
 async def aws_cli_help(
     service: str = Field(description="AWS service name (e.g., 's3', 'ec2', 'lambda', 'iam')"),
     command: str | None = Field(
@@ -81,7 +87,13 @@ async def aws_cli_help(
         return CommandHelpResult(help_text=f"Error retrieving help: {str(e)}")
 
 
-@mcp.tool()
+@mcp.tool(
+    annotations=ToolAnnotations(
+        title="AWS CLI Pipeline",
+        destructiveHint=True,
+        openWorldHint=True,
+    ),
+)
 async def aws_cli_pipeline(
     command: str = Field(description="AWS CLI command, optionally piped to Unix tools for filtering and transformation"),
     timeout: int | None = Field(


### PR DESCRIPTION
## Summary

Adds MCP tool annotations (`readOnlyHint`, `destructiveHint`, `openWorldHint`) to all tools to help LLMs better understand tool behavior and make safer decisions about tool execution.

## Changes

- Added `readOnlyHint: true` to `aws_cli_help` (documentation tool that only fetches help text)
- Added `destructiveHint: true` and `openWorldHint: true` to `aws_cli_pipeline` (executes AWS CLI commands that can create/modify/delete resources)
- Added `title` annotations for human-readable display

## Why This Matters

- Annotations provide semantic metadata that helps LLMs understand tool behavior
- LLMs can make better decisions about when to use tools and in what order
- Enables safer tool execution by distinguishing read-only from destructive operations
- MCP clients like Claude Code can auto-approve read-only tools without user confirmation

## Testing

- [x] `uv sync` - dependencies install successfully  
- [x] `uv run ruff check src/` - linter passes
- [x] Module imports successfully
- [x] Verified annotations are registered correctly via Python introspection:
  ```
  aws_cli_help: title='AWS CLI Help' readOnlyHint=True
  aws_cli_pipeline: title='AWS CLI Pipeline' destructiveHint=True openWorldHint=True
  ```
- Note: Live server verification requires AWS CLI installation

## Before/After

**Before:**
```python
@mcp.tool()
async def aws_cli_help(...):
    # No annotations
```

**After:**
```python
@mcp.tool(
    annotations=ToolAnnotations(
        title="AWS CLI Help",
        readOnlyHint=True,
    ),
)
async def aws_cli_help(...):
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)