### PR TITLE
fix: detect client disconnect and exit gracefully on stdio transport

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -82,4 +82,6 @@ ENV HOME="/home/appuser" \
 EXPOSE 8000
 
 # Set command to run the server
+# Ensure Docker sends SIGTERM for graceful shutdown
+STOPSIGNAL SIGTERM
 ENTRYPOINT ["aws-mcp"]

--- a/src/aws_mcp_server/__main__.py
+++ b/src/aws_mcp_server/__main__.py
@@ -8,6 +8,7 @@ import logging
 import os
 import signal
 import sys
+import threading
 
 from aws_mcp_server.server import logger, mcp, run_startup_checks
 
@@ -22,6 +23,67 @@ def handle_interrupt(signum, frame):
     """Handle interrupt signal by exiting immediately."""
     logger.info(f"Received signal {signum}, shutting down...")
     os._exit(0)
+
+
+def monitor_stdin_pipe():
+    """Monitor stdin pipe for hangup and exit when the MCP client disconnects.
+
+    When running over stdio transport (especially in Docker), the MCP client
+    communicates via stdin/stdout pipes. If the client exits without sending
+    SIGTERM (common with IDE integrations like VS Code/Cline), the write end
+    of the stdin pipe gets closed.
+
+    This thread uses poll() to detect POLLHUP (hang-up) on stdin without
+    consuming any data, so it doesn't interfere with FastMCP's own stdin
+    reading for the MCP protocol.
+
+    This prevents orphaned Docker containers that accumulate over time.
+    See: https://github.com/alexei-led/aws-mcp-server/issues/16
+    """
+    try:
+        import select
+
+        poll_obj = select.poll()
+        poll_obj.register(sys.stdin.fileno(), select.POLLHUP | select.POLLERR)
+
+        while True:
+            events = poll_obj.poll(2000)  # Check every 2 seconds
+            for _fd, event in events:
+                if event & (select.POLLHUP | select.POLLERR):
+                    logger.info("Stdin pipe closed (client disconnected), shutting down...")
+                    os._exit(0)
+    except (OSError, ValueError) as e:
+        logger.info(f"Stdin monitor error ({e}), shutting down...")
+        os._exit(0)
+    except AttributeError:
+        # select.poll() is not available on all platforms (e.g., some macOS builds).
+        # Fall back to periodic parent PID check.
+        _monitor_parent_fallback()
+
+
+def _monitor_parent_fallback():
+    """Fallback: monitor parent PID for platforms without select.poll().
+
+    On non-Docker environments where the server is a child of the MCP client,
+    detect parent process death by checking if ppid changes (reparented to init).
+    """
+    import time
+
+    original_ppid = os.getppid()
+    if original_ppid <= 1:
+        # Already PID 1 or child of init — no parent to monitor
+        logger.info("Stdin monitor fallback: no parent process to monitor, skipping")
+        return
+
+    while True:
+        time.sleep(2)
+        current_ppid = os.getppid()
+        if current_ppid != original_ppid:
+            logger.info(
+                f"Parent process changed ({original_ppid} -> {current_ppid}), "
+                "client likely disconnected. Shutting down..."
+            )
+            os._exit(0)
 
 
 def main():
@@ -45,6 +107,13 @@ def main():
             host = "0.0.0.0" if is_docker_environment() else "127.0.0.1"
             mcp.settings.host = host
             logger.info(f"SSE server binding to {host}:{mcp.settings.port}")
+        else:
+            # For stdio transport, monitor stdin pipe to detect client disconnection.
+            # Uses poll() for POLLHUP on Linux/Docker, falls back to parent PID
+            # monitoring on other platforms.
+            stdin_thread = threading.Thread(target=monitor_stdin_pipe, daemon=True)
+            stdin_thread.start()
+            logger.info("Stdin pipe monitor started for client disconnect detection")
 
         mcp.run(transport=TRANSPORT)
     except KeyboardInterrupt:


### PR DESCRIPTION
## Problem

When running as a Docker container with stdio transport, the MCP server continues running after the client (IDE) exits, causing orphaned containers to accumulate over time.

Reported in #16 — users have to periodically run `docker rm -f $(docker ps -qa)` to clean up.

## Solution

Added a stdin pipe monitor thread that detects when the MCP client disconnects:

- **Linux/Docker (primary):** Uses `select.poll()` to detect `POLLHUP` on stdin — the write end of the pipe being closed. This does **not** consume any data, so it doesn't interfere with FastMCP's own stdin reading for the MCP protocol.
- **macOS/fallback:** Falls back to parent PID monitoring — detects when the parent process dies and the server gets reparented to init.
- Monitor runs as a **daemon thread**, only started for **stdio** transport (not SSE).
- Added `STOPSIGNAL SIGTERM` to Dockerfile for clean Docker stops.

## Changes

- `src/aws_mcp_server/__main__.py` — Added `monitor_stdin_pipe()` and `_monitor_parent_fallback()` functions, started as daemon thread for stdio transport
- `deploy/docker/Dockerfile` — Added `STOPSIGNAL SIGTERM`

Fixes #16